### PR TITLE
Add STRTA to build and publish containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,7 @@ clean:
 	sudo rm -rf nginx/_site/
 	docker-compose run --rm gtsite-service clean
 
-start: build
-	docker-compose up
-
-stop:
-	docker-compose down
-
-publish: build
-	docker push ${SERVICE_IMG}:${TAG}
-	docker push ${STATIC_IMG}:${TAG}
-
-deploy: publish
+deploy:
 	terraform remote config \
 		-backend="s3" \
 		-backend-config="region=us-east-1" \

--- a/README.md
+++ b/README.md
@@ -6,21 +6,54 @@ composed of two pieces:
 1. A static content container with nginx
 2. A Spray server running GeoTrellis operations
 
-## Running Locally
-You need [Docker](https://www.docker.com/) to build and run the website.
-Once you have it, running the entire site is easy:
 
-```console
-> make start
+## Getting Started
+
+
+### Requirements
+
+- Vagrant 1.9+
+- VirtualBox 5.0+
+- AWS CLI 1.11+
+
+***TL;DR***
+```bash
+$ ./scripts/setup
+$ vagrant ssh
+$ ./scripts/server
 ```
 
-This will expose `localhost:8080` to listen for HTTP requests.
+A virtual machine is used to encapsulate Docker dependencies. `docker-compose` is used within the VM to manage running the application and developing against it.
+
+Vagrant is used to manage VirtualBox provisioning and configuration. Geotrellis Site follows the approach outlined [here](https://githubengineering.com/scripts-to-rule-them-all/) ("Scripts to Rule Them All") to have as consistent a development experience as possible. Use `scripts/setup` to provision a virtual machine. During provisioning `docker` and `docker-compose` will be installed on the guest machine. Once the VM is provisioned, run `scripts/server` to start a service that listens for HTTP requests on [http://localhost:8080](http://localhost:8080).
+
+
+```bash
+$ ./scripts/setup
+$ vagrant ssh
+$ ./scripts/server
+```
+
+## Scripts
+
+Helper scripts are located in the `./scripts` directory at the root of this project. These scripts are designed to encapsulate and perform commonly used actions such as starting a development server, accessing a development console, or running tests.
+
+| Script Name             | Purpose                                                      |
+|-------------------------|--------------------------------------------------------------|
+| `setup`                 | Provisions a vagrant VM										 |
+| `server`                | Starts a development server                                  |
+| `console`               | Gives access to a running container via `docker-compose run` |
+| `test`                  | Runs tests for project                           			 |
+| `cibuild`               | Invoked by CI server and makes use of `test`.                |
+| `cipublish`             | Publish container images to container image repositories.    |
+
+
 
 ## Deploying
 
-> NOTE: Requires terraform 0.7.5 or greater  
+> NOTE: Requires terraform 0.9.3 or greater.
 
-Deploying on AWS should be relatively simple as well Note that, because
+Deploying on AWS should be relatively simple as well. Note that, because
 the terraform state is stored on S3, any updates can be applied without
 having to tear down the previous deployment. Keep in mind, too, that
 containers are tagged according to the SHA of the commit from which they

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+services:
+  gtsite-service:
+    image: gtsite-service:${GIT_COMMIT}
+    build:
+      context: ./service
+      dockerfile: Dockerfile
+  gtsite-nginx:
+    image: gtsite-nginx:${GIT_COMMIT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,25 @@
-version: '2'
+version: '2.1'
 
 services:
   gtsite-service:
-    image: quay.io/geotrellis/gtsite-service
-    build:
-      context: ./service
-      dockerfile: Dockerfile
+    image: openjdk:8-jre
     ports:
       - "9090:9090"
+    entrypoint: ./sbt
+    command: srv/run docs/run
+    working_dir: /service
     volumes:
       - "${HOME}/.ivy2:/root/.ivy2"
       - "${HOME}/.m2:/root/.m2"
       - "${HOME}/.sbt:/root/.sbt"
+      - "./service/:/service"
+  gtsite-assets:
+    build:
+      context: ./static
+      dockerfile: Dockerfile
+    volumes:
+      - ./static:/build
+      - ./nginx:/handoff
   gtsite-nginx:
     image: quay.io/geotrellis/gtsite-nginx
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - "${HOME}/.m2:/root/.m2"
       - "${HOME}/.sbt:/root/.sbt"
       - "./service/:/service"
+      - "./service/srv/data:/srv/data"
   gtsite-assets:
     build:
       context: ./static

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${GT_SITE_DEBUG}" ]]; then
+    set -x
+fi
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Build application for staging or release.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+
+        make clean
+
+        echo "Running tests..."
+        ./scripts/test
+
+        docker-compose build gtsite-assets
+
+        echo "Building static asset bundle..."
+        docker-compose run --rm gtsite-assets
+    fi
+fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${GT_SITE_DEBUG}" ]]; then
+    set -x
+fi
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Publish images to Amazon ECR
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+
+        if [[ -n "${AWS_ECR_ENDPOINT}" ]]; then
+
+            echo "Building geotrellis-service JAR..."
+            docker-compose run --rm gtsite-service assembly
+
+            echo "Building gtsite-service and gtsite-nginx containers"
+            docker-compose run --rm --entrypoint "/bin/bash -c" gtsite-service \
+               "unzip -d /srv/data/hillshade/ -o /srv/data/hillshade/hills.zip"
+
+            GIT_COMMIT="${GIT_COMMIT}" \
+                docker-compose -f docker-compose.yml \
+                               -f docker-compose.test.yml build \
+                               gtsite-nginx gtsite-service
+
+            eval "$(aws ecr get-login)"
+            docker tag "gtsite-service:${GIT_COMMIT}" \
+                "${AWS_ECR_ENDPOINT}/gtsite-service:${GIT_COMMIT}"
+
+            docker tag "gtsite-nginx:${GIT_COMMIT}" \
+                "${AWS_ECR_ENDPOINT}/gtsite-nginx:${GIT_COMMIT}"
+
+            docker push "${AWS_ECR_ENDPOINT}/gtsite-service:${GIT_COMMIT}"
+            docker push "${AWS_ECR_ENDPOINT}/gtsite-nginx:${GIT_COMMIT}"
+        else
+            echo "ERROR: No AWS_ECR_ENDPOINT variable defined."
+            exit 1
+        fi
+
+    fi
+fi

--- a/scripts/console
+++ b/scripts/console
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eu
+
+DIR="$(dirname "$0")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0") SERVICE COMMAND[S]
+Use Docker Compose to run a command for a service, or drop into a console.
+
+Example: ./scripts/console gtsite-service \"./sbt\"
+"
+}
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        docker-compose -f "${DIR}/../docker-compose.yml" \
+                       run --rm --service-ports --entrypoint \
+                       "/bin/bash -c" "$1" "${@:2}"
+    fi
+fi

--- a/scripts/server
+++ b/scripts/server
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${GT_SITE_DEBUG}" ]]; then
+    set -x
+fi
+
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Starts docker-compose service
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        docker-compose up gtsite-nginx gtsite-service
+    fi
+fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${GT_SITE_DEBUG}" ]]; then
+    set -x
+fi
+
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Turn up vagrant development environment
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        vagrant up --provision
+    fi
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+if [[ -n "${GT_SITE_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Run various test suites.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        echo "Updating Scala dependencies"
+        docker-compose run --rm --no-deps gtsite-service update
+
+        echo "Running tests"
+        docker-compose run --rm gtsite-service test
+    fi
+fi

--- a/service/.dockerignore
+++ b/service/.dockerignore
@@ -1,0 +1,6 @@
+build/
+docs/
+srv/src
+srv/target/streams
+srv/target/resolution-cache
+srv/target/scala-2.10/classes/

--- a/service/srv/src/main/resources/application.conf
+++ b/service/srv/src/main/resources/application.conf
@@ -1,4 +1,4 @@
-geotrellis.catalog = srv/data/catalog.json
+geotrellis.catalog = /srv/data/catalog.json
 
 akka {
   loglevel = DEBUG

--- a/service/srv/src/main/scala/spray/srv/Model.scala
+++ b/service/srv/src/main/scala/spray/srv/Model.scala
@@ -8,9 +8,10 @@ import geotrellis.source._
  */
 object Model {
   def weightedOverlay(
-    layers: Iterable[String],
-    weights: Iterable[Int],
-    rasterExtent: Option[RasterExtent]): RasterSource =
+    layers:       Iterable[String],
+    weights:      Iterable[Int],
+    rasterExtent: Option[RasterExtent]
+  ): RasterSource =
     layers
       .zip(weights)
       .map {

--- a/service/srv/src/main/scala/spray/srv/SiteServiceActor.scala
+++ b/service/srv/src/main/scala/spray/srv/SiteServiceActor.scala
@@ -176,7 +176,8 @@ class SiteServiceActor(settings: SiteSettings) extends HttpServiceActor {
     case r @ HttpResponse(Found | MovedPermanently, _, _, _) ⇒
       Some(LogEntry(s"${r.status.intValue}: ${request.uri} -> ${r.header[HttpHeaders.Location].map(_.uri.toString).getOrElse("")}", WarningLevel))
     case response ⇒ Some(
-      LogEntry("Non-200 response for\n  Request : " + request + "\n  Response: " + response, WarningLevel))
+      LogEntry("Non-200 response for\n  Request : " + request + "\n  Response: " + response, WarningLevel)
+    )
   }
 
   def showRepoResponses(repo: String)(request: HttpRequest): HttpResponsePart ⇒ Option[LogEntry] = {
@@ -190,6 +191,7 @@ class SiteServiceActor(settings: SiteSettings) extends HttpServiceActor {
     Marshaller.delegate(MediaTypes.`text/html`) { (listing: DirectoryListing) ⇒
       listing.copy(
         files = listing.files.filterNot(file ⇒
-          file.getName.startsWith(".") || file.getName.startsWith("archetype-catalog")))
+          file.getName.startsWith(".") || file.getName.startsWith("archetype-catalog"))
+      )
     }(DirectoryListing.DefaultMarshaller)
 }

--- a/service/srv/src/main/scala/spray/srv/SiteSettings.scala
+++ b/service/srv/src/main/scala/spray/srv/SiteSettings.scala
@@ -21,11 +21,12 @@ import scala.collection.JavaConverters._
 import spray.util.SettingsCompanion
 
 case class SiteSettings(
-    interface: String,
-    port: Int,
-    devMode: Boolean,
-    mainVersion: String,
-    otherVersions: Seq[String]) {
+    interface:     String,
+    port:          Int,
+    devMode:       Boolean,
+    mainVersion:   String,
+    otherVersions: Seq[String]
+) {
 
   require(interface.nonEmpty, "interface must be non-empty")
   require(0 < port && port < 65536, "illegal port")
@@ -37,5 +38,6 @@ object SiteSettings extends SettingsCompanion[SiteSettings]("spray.site") {
     c getInt "port",
     c getBoolean "dev-mode",
     c getString "main-version",
-    c.getStringList("other-versions").asScala)
+    c.getStringList("other-versions").asScala
+  )
 }


### PR DESCRIPTION
# Overview

This repository uses a `Makefile` for much of the deployment pipeline, which is a non-standard setup. This PR brings the repo closer to the [Scripts to Rule them All](https://github.com/azavea/architecture/blob/master/doc/arch/adr-0000-scripts-to-rule-them-all.md) (STRTA) standard by adding `scripts/cibuild` and `scripts/cipublish`, which build the `gtsite-service` and `gtsite-nginx` containers and publish them to Amazon ECR.

Notable changes:
- Bumped the `docker-compose.yml` file version to `2.1` to take advantage of environment variables.
- Added `docker-compose.test.yml` to build the Amazon ECR images
- `cibuild` is a wrapper around the `Makefile` commands `make clean`, `make assets`, and `make build` (fixes #56) . 
- Replaced `TAG` with `GIT_COMMIT` in the `Makefile` to maintain naming consistency with other projects
- Speed up `gtsite-service` build times by adding extraneous files in `service` directory to a `dockerignore`
- `cipublish` pushes images to Amazon ECR, not quay.io (fixes #58 )

# Notes
- A few scala files were re-formatted by `sbt`, so i added them to this PR.

# Testing
```bash
export GIT_COMMIT=test
$ ./scripts/cibuild 
$ ./scripts/cipublish
```

Check the ECR repositories for [gtsite-service](https://console.aws.amazon.com/ecs/home?region=us-east-1#/repositories/gtsite-service#images;tagStatus=ALL) and [gtsite-nginx](https://console.aws.amazon.com/ecs/home?region=us-east-1#/repositories/gtsite-nginx#images;tagStatus=ALL), ensure that there is a `test` image available. Delete this image once testing is complete.

I also ran `scripts/cibuild` multiple times in a row to ensure idempotency (_note_: this script takes a very long time to run).