### PR TITLE
Add travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: bash
+cache:
+  directories:
+  - ${HOME}/.ivy2
+  - ${HOME}/.m2
+  - ${HOME}/.sbt
+services: docker
+addons:
+  apt:
+    packages:
+    - make
+env:
+  global:
+  - TERRAFORM_VERSION=0.9.6
+  - AWSCLI_VERSION=1.11.*
+  - DOCKER_COMPOSE_VERSION=1.13.*
+  - GT_SITE_SETTINGS_BUCKET=geotrellis-site-production-config-us-east-1
+  - AWS_DEFAULT_REGION=us-east-1
+  - secure: N1+4QYVCS0PfaUQiMYjFKpvXPZT/fzyHDLCV6yJDPAklkqQ1S6WeVjwDCd9+2IJy4wGKVSzsmf5DFpFutg+JKgiCVfVyr8bXnuqOcZzahGWqD5nEZc2qieYuhUrWcLtlH7TH8Cr+XF0syMJWneVfIvcDQqtvinGgJyyQdNkD4fo=
+  - secure: cDXxwiRVgWsipUMM+jKiR1zJBv8hJ/t+SU7Vln317Ehn03Lu3EzkEkftwopIc0YvtdETbTfw4ELt1Uua88tQnkR0fjhY1lljjmCkSJqTgIgqi73aznsmAz9BvfOkXYIISPwFOJ2fJYDL7ToyACPR0kJ79pxYAHQUlhcY/MGtbPs=
+  - secure: a5+FAF8HSdAY/1bAsEynlL8W9S9g42GG5rPHNnz3Yzme5SSnYAILPAu0zLqZkGoJmmSX6ZXTvIa1wZuskZeik62WRBMuWjuxshQsNonByDfqCzMI49AwV/i8IdpDLA8ic6BzDFQ0bYGWVka3/WU4ByqlMF5Tn3jxuFX6Z10tuwE=
+script:
+- mkdir -p ~/.local/bin
+- export PATH="~/.local/bin:$PATH"
+- pip install --user docker-compose==${DOCKER_COMPOSE_VERSION}
+- scripts/cibuild
+before_deploy:
+- wget -O terraform-${TERRAFORM_VERSION}.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+- unzip -d ~/.local/bin terraform-${TERRAFORM_VERSION}.zip
+- pip install --user awscli==${AWSCLI_VERSION}
+- rm terraform-${TERRAFORM_VERSION}.zip
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: scripts/deploy
+  on:
+    branch: master
+after_deploy:
+- rm deployment/terraform/${GT_SITE_SETTINGS_BUCKET}.{tfvars,tfplan}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,9 +2,9 @@ version: '2.1'
 
 services:
   gtsite-service:
-    image: gtsite-service:${GIT_COMMIT}
+    image: gtsite-service:${VERSION}
     build:
       context: ./service
       dockerfile: Dockerfile
   gtsite-nginx:
-    image: gtsite-nginx:${GIT_COMMIT}
+    image: gtsite-nginx:${VERSION}

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -6,12 +6,6 @@ if [[ -n "${GT_SITE_DEBUG}" ]]; then
     set -x
 fi
 
-if [[ -n "${GIT_COMMIT}" ]]; then
-    GIT_COMMIT="${GIT_COMMIT:0:7}"
-else
-    GIT_COMMIT="$(git rev-parse --short HEAD)"
-fi
-
 function usage() {
     echo -n \
 "Usage: $(basename "$0")

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -6,10 +6,10 @@ if [[ -n "${GT_SITE_DEBUG}" ]]; then
     set -x
 fi
 
-if [[ -n "${GIT_COMMIT}" ]]; then
-    GIT_COMMIT="${GIT_COMMIT:0:7}"
+if [[ -n "${TRAVIS_COMMIT}" ]]; then
+    VERSION="${TRAVIS_COMMIT:0:7}"
 else
-    GIT_COMMIT="$(git rev-parse --short HEAD)"
+    VERSION="$(git rev-parse --short HEAD)"
 fi
 
 function usage() {
@@ -33,20 +33,19 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docker-compose run --rm --entrypoint "/bin/bash -c" gtsite-service \
                "unzip -d /srv/data/hillshade/ -o /srv/data/hillshade/hills.zip"
 
-            GIT_COMMIT="${GIT_COMMIT}" \
-                docker-compose -f docker-compose.yml \
-                               -f docker-compose.test.yml build \
-                               gtsite-nginx gtsite-service
-
+            VERSION="${VERSION}" \
+            docker-compose -f docker-compose.yml \
+                           -f docker-compose.test.yml build \
+                              gtsite-nginx gtsite-service
             eval "$(aws ecr get-login)"
-            docker tag "gtsite-service:${GIT_COMMIT}" \
-                "${AWS_ECR_ENDPOINT}/gtsite-service:${GIT_COMMIT}"
+            docker tag "gtsite-service:${VERSION}" \
+                "${AWS_ECR_ENDPOINT}/gtsite-service:${VERSION}"
 
-            docker tag "gtsite-nginx:${GIT_COMMIT}" \
-                "${AWS_ECR_ENDPOINT}/gtsite-nginx:${GIT_COMMIT}"
+            docker tag "gtsite-nginx:${VERSION}" \
+                "${AWS_ECR_ENDPOINT}/gtsite-nginx:${VERSION}"
 
-            docker push "${AWS_ECR_ENDPOINT}/gtsite-service:${GIT_COMMIT}"
-            docker push "${AWS_ECR_ENDPOINT}/gtsite-nginx:${GIT_COMMIT}"
+            docker push "${AWS_ECR_ENDPOINT}/gtsite-service:${VERSION}"
+            docker push "${AWS_ECR_ENDPOINT}/gtsite-nginx:${VERSION}"
         else
             echo "ERROR: No AWS_ECR_ENDPOINT variable defined."
             exit 1

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+
+set -e
+
+if [[ -n "${GT_SITE_DEBUG}" ]]; then
+    set -x
+fi
+
+DIR="$(dirname "$0")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0") COMMAND OPTION[S]
+Deploy AWS infrastructure using Terraform.
+This script is only for use with Travis CI.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+        exit 0
+    fi
+    pushd "${DIR}/../"
+    ./scripts/cipublish
+    ./scripts/infra plan
+    ./scripts/infra apply
+    popd
+fi

--- a/scripts/infra
+++ b/scripts/infra
@@ -23,7 +23,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
         TERRAFORM_DIR="${DIR}/../deployment/terraform"
         echo
-        echo "Attempting to deploy application version [${TRAVIS_COMMIT}]..."
+        echo "Attempting to deploy application version [${TRAVIS_COMMIT:0:7}]..."
         echo "-----------------------------------------------------"
         echo
     fi
@@ -39,7 +39,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                     -backend-config="key=terraform/site/state"
 
                 terraform plan \
-                          -var="image_version=\"${TRAVIS_COMMIT}\"" \
+                          -var="image_version=\"${TRAVIS_COMMIT:0:7}\"" \
                           -var="remote_state_bucket=\"${GT_SITE_SETTINGS_BUCKET}\"" \
                           -out="${GT_SITE_SETTINGS_BUCKET}.tfplan"
                 ;;


### PR DESCRIPTION
Adds a Travis CI configuration to Install dependencies and run STRTA to build and deploy the Geotrellis Site service to ECS.

Notable changes:

- Added caching for Scala dependencies
- Added encrypted environment variables:
    - `AWS_ACCESS_KEY_ID`
    - `AWS_SECRET_ACCESS_KEY`
    - `AWS_ECR_ENDPOINT`
- Install software necessary for building, publishing, and deploying containers
    - `docker-compose`
    - `make`
    - `terraform`
    - `awscli`
- Added a deployment script that runs `cipublish` , `infra plan` and `infra apply`.
- Replaced `GIT_COMMIT` with `VERSION` to accommodate the `TRAVIS_COMMIT` environment variable.

# Notes
I've added scala dependency caching for this repo, but it won't be enabled for PR/branch builds until `master` is built/deployed. From the [Travis CI docs](https://docs.travis-ci.com/user/caching/#Fetching-and-storing-caches):
> If a branch does not have its own cache, Travis CI fetches the master branch cache.

# Testing
See Travis build output, namely [#13](https://travis-ci.org/geotrellis/geotrellis-site/builds/241268128). Additionally, I already ran a travis deploy to https://preview.geotrellis.io in [#11](https://travis-ci.org/geotrellis/geotrellis-site/builds/241262368)

Fixes #64 