### PR TITLE
Check if TTY is present before invoking `mesg`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,12 @@ Vagrant.configure("2") do |config|
     config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
     config.vm.synced_folder "./", "/home/vagrant/geotrellis-site"
 
+    config.vm.provision "shell" do |s|
+        s.inline = <<-SHELL
+            sed -i 's/^mesg n$/tty -s \\&\\& mesg n/g' /root/.profile
+        SHELL
+    end
+
     # Provisioning
     # Ansible is installed automatically by Vagrant.
     config.vm.provision "ansible_local" do |ansible|


### PR DESCRIPTION
# Overview

When provisioning VMs, users see an error that says `stdin: not a tty`. This error is an instance of mitchellh/vagrant#1673, and stems from the fact that the bash profile for Ubuntu's `root` user runs `mesg n` without checkking to see if a TTY is present (see [this](https://github.com/mitchellh/vagrant/issues/1673#issuecomment-28287711) comment on the issue for more detail). This PR Implements [this](https://github.com/mitchellh/vagrant/issues/1673#issuecomment-26650102) fix, which adds a line to `/root/.profile` to check to see if a TTY is present before invoking `mesg`.

Fixes #66 



# Testing

Run `vagrant provision`, ensure that the `stdin: not a tty` error is not present.