### PR TITLE
Re-add transit demo

### DIFF
--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "cdn" {
   logging_config {
     include_cookies = false
     bucket          = "${data.terraform_remote_state.core.logs_bucket_id}.s3.amazonaws.com"
-    prefix          = "CloudFront/"
+    prefix          = "CloudFront/Site/"
   }
 
   restrictions {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,6 @@ services:
       - gtsite-service
     ports:
       - "8080:8080"
+    volumes:
+      - ./nginx/_site:/var/www
+      - ./nginx/nginx.conf:/etc/nginx/default.conf

--- a/static/index.html
+++ b/static/index.html
@@ -88,6 +88,42 @@ title: GeoTrellis | Fast Raster Processing
           </div>
         </div>
       </div>
+      <div id="controller-3" class="demo-container item">
+        <h4 class="demo-controller-super-header">
+          GeoTrellis in Action:
+        </h4>
+        <h2 class="demo-controller-header">
+          Travelshed
+        </h2>
+        <p>
+          Given a starting location and a type of transportation, how far can I travel in a given amount of time? Move the <img src="https://api.tiles.mapbox.com/mapbox.js/v1.3.1/images/marker-icon-2x.png" style="height: 16px; margin-top: -4px"> marker around the map to find out.
+        </p>
+        <div class="controller-wrapper">
+          <div class="controller">
+            <div class="row">
+              <div class="col-sm-6">
+                <h6 class="demo-controller-label">Type of Transportation</h6>
+              </div>
+              <div class="col-sm-6">
+
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-sm-12">
+                <div class="btn-group btn-group-justified" data-toggle="buttons">
+                  <label class="btn btn-primary">
+                    <input type="radio" name="options" id="option1" value="walking"><img src="img/walk-icon.png" class="demo-map-transit-icon"> Walk
+                  </label>
+                  <label class="btn btn-primary active">
+                    <input type="radio" name="options" id="option2" value="walking,train,bus" checked><img src="img/train-icon.png" class="demo-map-transit-icon"> Transit
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="controller-3-slider-1"></div>
+      </div>
     </div>
   </div>
   <div id="carousel-map" class="carousel slide carousel-fade">
@@ -176,7 +212,7 @@ title: GeoTrellis | Fast Raster Processing
         <p>Check out these demo projects that use GeoTrellis. The source for these projects and more can be found at <a href="http://github.com/geotrellis">our Github account.</a></p>
       </div>
       <div class="col-sm-3 col-sm-offset-2">
-        <a class="demo" href="http://transit.geotrellis.com/">
+        <a class="demo" href="https://transit.geotrellis.io/">
           <img src="/img/demo_01.jpg" />
           <h4>GeoTrellis Transit</h4>
         </a>

--- a/static/js/demo/main.js
+++ b/static/js/demo/main.js
@@ -31,6 +31,8 @@ function(wo_ui, hs_ui, transit, maps){
           switch (to) {
             case 1: hs_ui.init();
               break;
+            case 2: transit.init();
+              break;
           }
         }
         

--- a/static/js/demo/transit.js
+++ b/static/js/demo/transit.js
@@ -33,7 +33,7 @@ define([
         mapLayer = null;
     }
 
-    mapLayer = new L.TileLayer.WMS("http://transit.geotrellis.com/api/travelshed/wms", {
+    mapLayer = new L.TileLayer.WMS("https://transit.geotrellis.io/api/travelshed/wms2", {
                     latitude: marker.getLatLng().lat,
                     longitude: marker.getLatLng().lng,
                     time: time,


### PR DESCRIPTION
Re-adds the transit demo to the carousel, which was removed in #68. 

Changes:
- Revert HTML/JavaScript changes made in #68
- Updated `static/js/demo/transit.js` to make WMS requests to https://transit.geotrellis.io/api/travelshed/wms2, which can handle uppercase query string parameters.
- Added volumes to `docker-compose.yml` so that `gtsite-nginx` picks up updates to static files without rebuilding the container.
- Prefix CloudFront logs with `CloudFront/Site` to differentiate from other CloudFront distributions using the same logs bucket.

# Testing
- Build static assets, and start nginx
```bash
$ make clean
$ docker-compose build gtsite-assets
$ docker-compose run --rm gtsite-assets
$ ./scripts/server
```
- The site will be available at http://localhost:8080. Ensure that the transit demo is in the carousel.