### PR TITLE
Bump desired instances to 2 services

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -30,7 +30,7 @@ variable "ssl_certificate_arn" {
 }
 
 variable "website_ecs_desired_count" {
-  default = "1"
+  default = "2"
 }
 
 variable "website_ecs_min_count" {
@@ -42,9 +42,9 @@ variable "website_ecs_max_count" {
 }
 
 variable "website_ecs_deployment_min_percent" {
-  default = "100"
+  default = "50"
 }
 
 variable "website_ecs_deployment_max_percent" {
-  default = "200"
+  default = "100"
 }


### PR DESCRIPTION
Allows deployments to replace old services without downtime.

This change should resolve the intermittent service outages that @lossyrob noticed in the Slack channel.

# Testing
- Create a new task definition for `ProductionWebsite` service in the ECS console
- Update the `ProductionWebsite` service to use the new task definition
- Make sure that `ProductionWebsite` picks up the new task definition.

Connects geotrellis/geotrellis-site-deployment#18