### PR TITLE
Build static site as a part of provisioning

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -10,7 +10,7 @@ fi
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
-Turn up vagrant development environment
+Update development environment
 "
 }
 
@@ -18,7 +18,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        vagrant up --provision
-        vagrant ssh -c "cd /home/vagrant/geotrellis-site && ./scripts/update"
+		docker-compose build gtsite-assets
+		docker-compose run --rm gtsite-assets
     fi
 fi


### PR DESCRIPTION
# Overview

Currently, the development VM provisioning process doesn't create the site's static assets, which are necessary for building the `nginx` container. As a result, running `scripts/server` fails on a newly provisioned VM. This PR addresses that issue by making `scripts/setup` run `scripts/update`, which builds the static site.

# Testing
Destroy and re-provision a VM, and then run `scripts/server`. Ensure that you can reach the site at http://localhost:8080
```bash
$ vagrant destroy
$ rm -rf ./nginx/_site
$ ./scripts/setup
$ vagrant ssh
vagrant@vagrant-ubuntu-trusty64 $ ./scripts/server
```
Fixes #73 