### PR TITLE
Update the version of yajl-ruby used by Jekyll

### DIFF
--- a/static/Gemfile.lock
+++ b/static/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       faraday (~> 0.8, < 0.10)
     toml (0.1.2)
       parslet (~> 1.5.0)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.2.3)
 
 PLATFORMS
   ruby
@@ -79,4 +79,4 @@ DEPENDENCIES
   mini_magick (~> 4.2.0)
 
 BUNDLED WITH
-   1.11.2
+   1.16.0


### PR DESCRIPTION
The following CVE was reported by GitHub for version 1.2.1:

- https://nvd.nist.gov/vuln/detail/CVE-2017-16516
- https://github.com/geotrellis/geotrellis-site/network/dependencies

(This is low priority because the only user input `yajl-ruby` is accepting is from the repository. I am mostly just doing it to make the warnings go away.)

---

**Testing**

Review the Travis CI build output: https://travis-ci.org/geotrellis/geotrellis-site/builds/309033592