### PR TITLE
Remove default for SSL certificate ARN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ deployment/GT-SITE.tfstate*
 deployment/terraform/.terraform
 *tfstate*
 *.tfplan
+*.tfvars

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,42 @@
+# Amazon Web Services Deployment
+
+Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) and the [AWS Command Line Interface (CLI)](http://aws.amazon.com/cli/).
+
+## Table of Contents
+
+* [AWS Credentials](#aws-credentials)
+* [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `geotrellis`:
+
+```bash
+$ aws --profile geotrellis configure
+AWS Access Key ID [********************]:
+AWS Secret Access Key [********************]:
+Default region name [us-east-1]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+Next, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+$ export GT_SITE_SETTINGS_BUCKET="geotrellis-site-production-config-us-east-1"
+$ export AWS_PROFILE="geotrellis"
+# TRAVIS_COMMIT is the 7-digit SHA for the commit you want to deploy
+$ export TRAVIS_COMMIT=1a3b5c7
+$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra.sh plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra.sh apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -25,9 +25,7 @@ variable "cdn_price_class" {
   default = "PriceClass_200"
 }
 
-variable "ssl_certificate_arn" {
-  default = "arn:aws:acm:us-east-1:896538046175:certificate/a416c2af-00dd-4afd-8c71-dd32edefa839"
-}
+variable "ssl_certificate_arn" {}
 
 variable "website_ecs_desired_count" {
   default = "2"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,14 @@
+version: '2.1'
+services:
+  terraform:
+    image: "quay.io/azavea/terraform:0.9.6"
+    volumes:
+      - ~/.aws:/root/.aws
+      - ./:/usr/local/src
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-geotrellis}
+      - TRAVIS_COMMIT=${TRAVIS_COMMIT}
+      - GT_SITE_DEBUG=1
+      - GT_SITE_SETTINGS_BUCKET=${GT_SITE_SETTINGS_BUCKET:-geotrellis-site-production-config-us-east-1}
+    working_dir: /usr/local/src
+    entrypoint: bash

--- a/scripts/infra
+++ b/scripts/infra
@@ -33,12 +33,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         case "${1}" in
             plan)
+                aws s3 cp "s3://${GT_SITE_SETTINGS_BUCKET}/terraform/site/terraform.tfvars" \
+                    "${GT_SITE_SETTINGS_BUCKET}.tfvars"
+
                 rm -rf .terraform/ terraform.tfstate*
                 terraform init \
                     -backend-config="bucket=${GT_SITE_SETTINGS_BUCKET}" \
                     -backend-config="key=terraform/site/state"
 
                 terraform plan \
+                          -var-file="${GT_SITE_SETTINGS_BUCKET}.tfvars" \
                           -var="image_version=\"${TRAVIS_COMMIT:0:7}\"" \
                           -var="remote_state_bucket=\"${GT_SITE_SETTINGS_BUCKET}\"" \
                           -out="${GT_SITE_SETTINGS_BUCKET}.tfplan"

--- a/service/project/plugins.sbt
+++ b/service/project/plugins.sbt
@@ -1,6 +1,7 @@
 resolvers += "spray repo" at "http://repo.spray.io"
 
 libraryDependencies ++= Seq(
+  "javax.media" % "jai_core" % "1.1.3" from "http://download.osgeo.org/webdav/geotools/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar",
   "com.decodified" % "scala-ssh" % "0.6.2",
   "org.bouncycastle" % "bcprov-jdk16" % "1.46",
   "com.jcraft" % "jzlib" % "1.1.1"

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.3
 
 # `jekyll` requires a JS runtime.
-RUN apt-get update && apt-get install -y node rsync
+RUN apt-get update && apt-get install -y nodejs rsync
 
 RUN mkdir -p /build /handoff
 WORKDIR /build


### PR DESCRIPTION
# Overview

This PR removes the default value for `ssl_certificate_arn` (which is now outdated) from `variables.tf`, and updates `scripts/infra` to use a .tfvars file to make it easier to override other defaults in the future.

## Changes
- Remove default value for `ssl_certficate_arn`
- Updated `scripts/infra` to use a `.tfvars` file.
- Add `docker-compose.ci.yml` for local deployments.

Fixes #82 

# Testing
- Run `scripts/infra` according to the instructions in the new deployment README, ensure no changes are necessary.
```bash
$ export GT_SITE_SETTINGS_BUCKET=geotrellis-site-production-config-us-east-1
$ export AWS_PROFILE=geotrellis
$ export TRAVIS_COMMIT=$(git rev-parse --short master)
$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
```
