### PR TITLE
 Use --no-include-email flag when logging into ECR

### DIFF
--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -37,7 +37,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docker-compose -f docker-compose.yml \
                            -f docker-compose.test.yml build \
                               gtsite-nginx gtsite-service
-            eval "$(aws ecr get-login)"
+            eval "$(aws ecr get-login --no-include-email)"
             docker tag "gtsite-service:${VERSION}" \
                 "${AWS_ECR_ENDPOINT}/gtsite-service:${VERSION}"
 


### PR DESCRIPTION
Fixes broken `cipublish` step during deploys.

# Testing
- Ran a successful deployment from Travis. Build logs [here](https://travis-ci.org/geotrellis/geotrellis-site/jobs/403671896).