### PR TITLE
ScalaDocs for 2.0

### DIFF
--- a/static/_includes/scaladoc-versions.html
+++ b/static/_includes/scaladoc-versions.html
@@ -1,12 +1,11 @@
 <div class="option-pane">
   <ul>
     <li><a href="https://geotrellis.github.io/scaladocs/latest/#geotrellis.package">Latest</a></li>
+    <li><a href="https://geotrellis.github.io/scaladocs/2.0/#geotrellis.package">Version 2.0</a></li>
+    <li><a href="https://geotrellis.github.io/scaladocs/1.2/#geotrellis.package">Version 1.2</a></li>
+    <li><a href="https://geotrellis.github.io/scaladocs/1.1/#geotrellis.package">Version 1.1</a></li>
     <li><a href="https://geotrellis.github.io/scaladocs/1.1/#geotrellis.package">Version 1.1</a></li>
     <li><a href="https://geotrellis.github.io/scaladocs/1.0/#geotrellis.package">Version 1.0</a></li>
     <li><a href="https://geotrellis.github.io/scaladocs/0.10/#geotrellis.package">Version 0.10</a></li>
-    <li><a href="https://geotrellis.github.io/scaladocs/0.9/#geotrellis.package">Version 0.9</a></li>
-    <li><a href="https://geotrellis.github.io/scaladocs/0.8/#geotrellis.package">Version 0.8</a></li>
-    <li><a href="https://geotrellis.github.io/scaladocs/0.7/#geotrellis.package">Version 0.7</a></li>
-    <li><a href="https://geotrellis.github.io/scaladocs/0.6/#geotrellis.package">Version 0.6</a></li>
   </ul>
 </div>

--- a/static/documentation.html
+++ b/static/documentation.html
@@ -35,7 +35,7 @@ title: Geotrellis | Fast Raster Processing
     <hr class="half" />
     <div class="row">
       <div class="col-sm-8">
-        Our User Guide is hosted on <a href="https://readthedocs.org/">ReadTheDocs</a>,
+        Our <a href="https://geotrellis.readthedocs.io/en/latest/">User Guide</a> is hosted on ReadTheDocs,
         and provides all the conceptual information required to use GeoTrellis.
       </div>
       <div class="col-sm-4">


### PR DESCRIPTION
- Updating scala docs link
- Removed `ReadTheDocs` link and pointed to the hosted user guide instead