### PR TITLE
Nitpicky capitalization and grammar tweaks

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,12 +1,12 @@
 <footer class="footer">
     <div class="footer__inner">
-        <a href="/"><img class="footer__brand" src="{{ site.baseurl }}/assets/images/geotrellis-logo-darkbg.svg" alt="Geotrellis logo"></a>
+        <a href="/"><img class="footer__brand" src="{{ site.baseurl }}/assets/images/geotrellis-logo-darkbg.svg" alt="GeoTrellis logo"></a>
         <nav>
             <a role="menuitem" href="{{ site.url }}/documentation">
                 Documentation
             </a>
             <a role="menuitem" href="https://github.com/geotrellis/geotrellis">
-                Github
+                GitHub
             </a>
         </nav>
         <small class="footer__copyright">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,7 +1,7 @@
 <div class="navbar">
     <div class="navbar__inner">
         <a href="/" class="navbar__brand" title="Azavea Careers homepage">
-            <img src="{{ site.baseurl }}/assets/images/geotrellis-logo-darkbg.svg" alt="Geotrellis logo">
+            <img src="{{ site.baseurl }}/assets/images/geotrellis-logo-darkbg.svg" alt="GeoTrellis logo">
         </a>
 
         <nav id="navbar" class="navbar__nav">
@@ -22,7 +22,7 @@
                 <li class="navbar__list-item" role="presentation">
                     <a class="navbar__link" role="menuitem" href="https://github.com/geotrellis/geotrellis">
                         <i class="fab fa-github navbar__link-icon"></i>
-                        Github
+                        GitHub
                     </a>
                 </li>
             </ul>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -31,7 +31,7 @@ intro:
 # demos section
 demos:
   title: "Demos"
-  blurb: "We are always figuring out new ways to leverage the powerful processing power of Geotrellis. The source code for demos can be found at our [Github account.](http://github.com/geotrellis)"
+  blurb: "We are always figuring out new ways to leverage the powerful processing power of GeoTrellis. The source code for demos can be found on our [GitHub account](http://github.com/geotrellis)."
 
 # demos section
 

--- a/_sass/01_settings/_color.scss
+++ b/_sass/01_settings/_color.scss
@@ -13,7 +13,7 @@ $brand-steel: #D0D9E1;
 $brand-porcelain: #E5EAEE;
 $brand-off-white: #F4F6F8;
 
-// Geotrellis colors
+// GeoTrellis colors
 $brand-navy: #1c2d3f;
 $brand-blue: #417dbf;
 $brand-yellow: #e3d262;


### PR DESCRIPTION
## Overview

- Github to GitHub
- Geotrellis to GeoTrellis
- Adjust grammar ("at our" to "on our")

Connects https://github.com/geotrellis/geotrellis-site/issues/92.

## Demo

![GeoTrellis - Home 2019-08-12 13-22-37](https://user-images.githubusercontent.com/1774125/62884492-b07cd280-bd04-11e9-8b50-8f9b0dedaeb5.png)

vs.

![GeoTrellis - Home 2019-08-12 13-23-07](https://user-images.githubusercontent.com/1774125/62884494-b4105980-bd04-11e9-9d99-bc63b350e150.png)

## Testing Instructions

```bash
[rocky@algiers geotrellis-site] (feature/jrb/nitpicks)$ ./scripts/server
...
```

Visit the site at http://localhost:4000.

