### PR TITLE
Add trademark text and grant info

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,25 +1,36 @@
 <footer class="footer">
     <div class="footer__inner">
-        <a href="/"><img class="footer__brand" src="{{ site.baseurl }}/assets/images/geotrellis-logo-darkbg.svg" alt="GeoTrellis logo"></a>
-        <nav>
-            <a role="menuitem" href="{{ site.url }}/documentation">
-                Documentation
-            </a>
-            <a role="menuitem" href="https://github.com/geotrellis/geotrellis">
-                GitHub
-            </a>
-        </nav>
-        <small class="footer__copyright">
-                © 2016 - {{ 'now' | date: "%Y" }} <a href="www.azavea.com">Azavea</a> Inc., using technology to inform research for civic and social impact. All rights reserved.
+        <div class="footer__main-content">
+            <a href="/" class="footer__brand"><img src="{{ site.baseurl }}/assets/images/geotrellis-logo-darkbg.svg" alt="GeoTrellis logo"></a>
+
+            <nav class="footer__nav">
+                <a role="menuitem" href="{{ site.url }}/documentation">
+                    <i class="fal fa-book navbar__link-icon"></i>
+                    Documentation
+                </a>
+                <a role="menuitem" href="https://github.com/geotrellis/geotrellis">
+                    <i class="fab fa-github navbar__link-icon"></i> 
+                    GitHub
+                </a>
+            </nav>
+        </div>
+
+        <small class="footer__text footer__text--copyright">
+            © 2016 - {{ 'now' | date: "%Y" }} <a href="www.azavea.com">Azavea</a> Inc., using technology to inform research for civic and social impact. All rights reserved. 
+            Some GeoTrellis features have been supported by grants from the U.S. Dept of Energy (DE-SC0011303) and NASA (NNX16CS04C).
         </small>
+        <small class="footer__text footer__text--trademark">
+            GeoTrellis and the GeoTrellis logo are trademarks of the Eclipse Foundation, Inc.
+        </small>
+
         <ul class="footer__bottom">
             <li>
-                <a href="https://azavea.com/terms-of-use/">
+                <a href="https://azavea.com/terms-of-use/"> 
                     Terms of Use
                 </a>
             </li>
             <li>
-                <a href="https://azavea.com/privacy-policy/">
+                <a href="https://azavea.com/privacy-policy/"> 
                     Privacy Policy
                 </a>
             </li>

--- a/_sass/06_components/_footer.scss
+++ b/_sass/06_components/_footer.scss
@@ -3,7 +3,6 @@
     position: relative;
     background: $footer-background;
     color: $footer-color;
-    text-align: center;
     -webkit-font-smoothing: antialiased; 
     -moz-osx-font-smoothing: grayscale;
 
@@ -23,21 +22,52 @@
         max-width: $main-max-width;
         margin: auto;
         padding: 2.5rem;
+        text-align: center;
 
         @media all and (min-width: $bp-small-3) {
+            align-items: flex-start;
+            text-align: left;
             padding: 3.5rem 2.5rem;
         }
     }
 
+    &__main-content {
+        width: 100%;
+
+        @media all and (min-width: $bp-small-3) {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+    }
+
     &__brand {
+        display: block;
+        margin: 0 auto 1rem;
         width: 15rem;
 
         @media all and (min-width: $bp-small-3) {
+            margin: 0 0 1rem 0;
             width: 20rem;
         }
     }
+
+    &__text {
+        display: block;
+        max-width: 60rem;
+        @include text(200, $color: $brand-porcelain);
+    }
+
+    &__text--trademark {
+        opacity: 0.5;
+    }
     
-    nav {
+    &__nav {
+        @media all and (max-width: $bp-small) {
+            display: flex;
+            flex-direction: column;   
+        }     
+
         a:not(.btn) {
             margin: $pad-compact $pad-small;
 
@@ -53,6 +83,10 @@
         line-height: 1.5;
         text-transform: uppercase;
         font-size: 1.2rem;
+
+        @media all and (max-width: $bp-small-3) {
+            justify-content: center;
+        }
 
         li {
             text-indent: 0;


### PR DESCRIPTION
# Overview
The new GeoTrellis site was missing key information. This PR adds it to the footer.

# Demo
![Screen Shot 2019-08-15 at 9 22 07 AM](https://user-images.githubusercontent.com/5672295/63097546-b78f2500-bf3e-11e9-9361-532826befc1d.png)
![Screen Shot 2019-08-15 at 9 21 58 AM](https://user-images.githubusercontent.com/5672295/63097545-b78f2500-bf3e-11e9-9c20-31ced8c94eca.png)


# Notes
@rcheetham I saw the example you shared in #98, but was hoping to use text. I pulled what we had in the previous GeoTrellis site iteration: 
![Screen Shot 2019-08-15 at 9 27 36 AM](https://user-images.githubusercontent.com/5672295/63097642-fd4bed80-bf3e-11e9-8589-4b454e3fa0f2.png)

Is what I have here sufficient, or should I try to include the Eclipse/LocationTech reference as a logo?

# Testing
- `git pull`
- Ensure that new footer design looks good at various screen widths.

Closes #99, #98