### PR TITLE
Update link for building footprints demo card

### DIFF
--- a/_data/demos.yml
+++ b/_data/demos.yml
@@ -8,5 +8,5 @@
   blurb: "Hover on a building footprint to see its min elevation, max elevation, and the delta between them. The larger a building's elevation delta compared to all other buildings within the current viewport, the more saturated its fill."
   image: "./assets/images/demo_building-footprint.jpg"
   image-alt: "Screenshot of the Elected Officials and Districts tool in a laptop."
-  demo-url: https://demos.azavea.com/cooling-towers
+  demo-url: https://demos.azavea.com/building-footprint-comparison
   source-code-url: 


### PR DESCRIPTION
It was incorrectly pointing to the tower cooling demo.

Fixes https://github.com/geotrellis/geotrellis-site/issues/104

---

**Testing**

Review the screenshot below that shows the source behind the **See demo** link for that card:

<img width="832" alt="Screen Shot 2019-10-22 at 11 43 34 AM" src="https://user-images.githubusercontent.com/43639/67304040-44b3a480-f4c1-11e9-8eb0-a675f78378c7.png">
