### PR TITLE
Fixup broken links on Geotrellis site

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,7 +16,7 @@
         </div>
 
         <small class="footer__text footer__text--copyright">
-            © 2016 - {{ 'now' | date: "%Y" }} <a href="www.azavea.com">Azavea</a> Inc., using technology to inform research for civic and social impact. All rights reserved. 
+            © 2016 - {{ 'now' | date: "%Y" }} <a href="https://www.azavea.com">Azavea</a> Inc., using technology to inform research for civic and social impact. All rights reserved. 
             Some GeoTrellis features have been supported by grants from the U.S. Dept of Energy (DE-SC0011303) and NASA (NNX16CS04C).
         </small>
         <small class="footer__text footer__text--trademark">

--- a/_pages/documentation.md
+++ b/_pages/documentation.md
@@ -18,7 +18,7 @@ title: "Documentation"
 # intro section
 intro: 
   title: Documentation
-  blurb: In addition to our API documentation, we provide a detailed [User Guide.](https://docs.geotrellis.io/en/latest/) Please see that guide for setup instructions, tutorials, and explanations of GeoTrellis/GIS concepts.
+  blurb: In addition to our API documentation, we provide a detailed [User Guide.](https://geotrellis.readthedocs.io/en/latest/) Please see that guide for setup instructions, tutorials, and explanations of GeoTrellis/GIS concepts.
   body: If you can’t find exactly what you’re looking for in either our Guide or API docs, feel free to join us in our [Gitter channel,](https://gitter.im/geotrellis/geotrellis) where we can answer your questions live.
   button:
     text: Go to docs
@@ -31,13 +31,13 @@ user-guide:
   blurb: Our [User Guide](https://geotrellis.readthedocs.io/en/latest/) provides all the conceptual information required to use GeoTrellis.
   links:
     - text: Home
-      url: https://docs.geotrellis.io 
+      url: https://geotrellis.readthedocs.io/en/latest/
     - text: Setup
-      url: https://docs.geotrellis.io/en/latest/tutorials/setup.html 
+      url: https://geotrellis.readthedocs.io/en/latest/tutorials/setup.html
     - text: Quick Start
-      url: https://docs.geotrellis.io/en/latest/tutorials/quickstart.html 
+      url: https://geotrellis.readthedocs.io/en/latest/tutorials/quickstart.html
     - text: Core Concepts
-      url: https://docs.geotrellis.io/en/latest/guide/core-concepts.html 
+      url: https://geotrellis.readthedocs.io/en/latest/guide/core-concepts.html
 
 # user guide section
 
@@ -69,7 +69,7 @@ scala-api:
 # contributing section
 contributing:
   title: Contributing to GeoTrellis
-  blurb: GeoTrellis is an open source project, so contributions of any kind are welcome and appreciated! Contributors will need to sign a CLA (Contributor’s License Agreement). These details and others relating to GeoTrellis contributions can be found [here.](https://docs.geotrellis.io/en/latest/CONTRIBUTING.html)
+  blurb: GeoTrellis is an open source project, so contributions of any kind are welcome and appreciated! Contributors will need to sign a CLA (Contributor’s License Agreement). These details and others relating to GeoTrellis contributions can be found [here.](https://geotrellis.readthedocs.io/en/latest/CONTRIBUTING.html)
 # contributing section
 
 ---

--- a/_sass/06_components/_links-list.scss
+++ b/_sass/06_components/_links-list.scss
@@ -6,4 +6,8 @@
         padding: 0 $pad-small;
         color: $brand-pewter;
     }
+
+    &__inner {
+        list-style-type: none;
+    }
 }


### PR DESCRIPTION
# Overview
Links referencing the GeoTrellis docs were broken throughout the documentation page. I also noticed an issue with the Azavea link in the footer and fixed some weird bullet styles.

# Demo
Bullets removed
<img width="1792" alt="Screen Shot 2020-05-27 at 9 59 49 AM" src="https://user-images.githubusercontent.com/5672295/82999499-fd663700-a000-11ea-97b3-719352d01d70.png">

# Testing
- `git pull` 
- Click on every link on the Documentation page. You shouldn't get a 403 page for any of them.
- Click on the links in the footer. "

Closes #109